### PR TITLE
hタグの追加

### DIFF
--- a/src/components/ui/input/index.tsx
+++ b/src/components/ui/input/index.tsx
@@ -35,16 +35,28 @@ export const Input: React.FC = () => {
   ) => {
     const block = findBlock(blocks, blockId)
     const input = e.target as HTMLInputElement
-
-    if (block?.type === "input" && input.value === "/h1") {
+    const validTags = ["/h1", "/h2", "/h3"]
+    if (block?.type === "input" && validTags.includes(input.value)) {
       e.preventDefault()
-      updateBlockType(blockId, "headingOne")
+      switch (input.value) {
+        case "/h1":
+          updateBlockType(blockId, "headingOne")
+          break
+        case "/h2":
+          updateBlockType(blockId, "headingTwo")
+          break
+        case "/h3":
+          updateBlockType(blockId, "headingThree")
+          break
+        default:
+          break
+      }
       updateBlockContent(blockId, "")
       animateBlockFocus(blockId, focusBlockElement)
       return
     }
 
-    if (block?.type === "headingOne" && input.value === "/p") {
+    if (block?.type !== "input" && input.value === "/p") {
       e.preventDefault()
       updateBlockType(blockId, "input")
       updateBlockContent(blockId, "")

--- a/src/lib/hooks/useBlocks.tsx
+++ b/src/lib/hooks/useBlocks.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import type { Block } from "@/types/type"
+import type { Block, BlockType } from "@/types/type"
 import { useState } from "react"
 import { v4 as uuidv4 } from "uuid"
 import { findIndexBlocks } from "../utils/textBlockUtils"
@@ -37,7 +37,7 @@ export const useBlocks = (
     )
   }
 
-  const updateBlockType = (blockId: string, type: Block["type"]) => {
+  const updateBlockType = (blockId: string, type: BlockType) => {
     setBlocks((prev) =>
       prev.map((block) => (block.id === blockId ? { ...block, type } : block))
     )

--- a/src/lib/utils/textBlockUtils.ts
+++ b/src/lib/utils/textBlockUtils.ts
@@ -43,6 +43,10 @@ export const getHeadingStyles = (type: BlockType): string => {
   switch (type) {
     case "headingOne":
       return "text-3xl font-bold"
+    case "headingTwo":
+      return "text-2xl font-bold"
+    case "headingThree":
+      return "text-xl font-bold"
     default:
       return "leading-normal"
   }

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -1,6 +1,6 @@
 import type { ChangeEvent, KeyboardEvent } from "react"
 
-export type BlockType = "input" | "headingOne"
+export type BlockType = "input" | "headingOne" | "headingTwo" | "headingThree"
 
 export type Block = {
   id: string

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,20 +1,21 @@
-import type { Config } from "tailwindcss";
+import type { Config } from "tailwindcss"
 
 const config: Config = {
   content: [
     "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
-    "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/app/**/*.{js,ts,jsx,tsx,mdx}"
   ],
   theme: {
     extend: {
       backgroundImage: {
         "gradient-radial": "radial-gradient(var(--tw-gradient-stops))",
         "gradient-conic":
-          "conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))",
-      },
-    },
+          "conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))"
+      }
+    }
   },
-  plugins: [],
-};
-export default config;
+  safelist: ["text-3xl", "font-bold", "leading-normal"],
+  plugins: []
+}
+export default config

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -15,7 +15,7 @@ const config: Config = {
       }
     }
   },
-  safelist: ["text-3xl", "font-bold", "leading-normal"],
+  safelist: ["text-3xl", "text-2xl", "text-xl", "font-bold", "leading-normal"],
   plugins: []
 }
 export default config


### PR DESCRIPTION
closed #19 

- h2タグの作成
- h3タグの作成
- `/hX`でタグが作成されなかったバグの修正

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 入力コンポーネントでのブロックタイプの処理が改善され、"/h1"、"/h2"、"/h3"のタグに対応。
  - 新しいブロックタイプ「headingTwo」と「headingThree」が追加され、スタイルが適用されるようになりました。

- **バグ修正**
  - 入力値に基づくブロックタイプの更新条件が拡張され、より柔軟な処理が可能に。

- **ドキュメント**
  - Tailwind CSSの設定が整理され、特定のクラス名を常に生成するための`safelist`プロパティが追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->