### PR TITLE
fix: README修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,68 +1,34 @@
-This is a [Next.js](https://nextjs.org/) project bootstrapped with [`c3`](https://developers.cloudflare.com/pages/get-started/c3).
+# Vimocho
 
-## Getting Started
+## 概要
 
-First, run the development server:
+Notion と Vim を組み合わせた Web アプリ
 
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
-```
+## 開発背景
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Notion を Vim のように操作したかったから
 
-## Cloudflare integration
+## 開発者
 
-Besides the `dev` script mentioned above `c3` has added a few extra scripts that allow you to integrate the application with the [Cloudflare Pages](https://pages.cloudflare.com/) environment, these are:
-  - `pages:build` to build the application for Pages using the [`@cloudflare/next-on-pages`](https://github.com/cloudflare/next-on-pages) CLI
-  - `preview` to locally preview your Pages application using the [Wrangler](https://developers.cloudflare.com/workers/wrangler/) CLI
-  - `deploy` to deploy your Pages application using the [Wrangler](https://developers.cloudflare.com/workers/wrangler/) CLI
+[sekibuuun](https://github.com/sekibuuun)
 
-> __Note:__ while the `dev` script is optimal for local development you should preview your Pages application as well (periodically or before deployments) in order to make sure that it can properly work in the Pages environment (for more details see the [`@cloudflare/next-on-pages` recommended workflow](https://github.com/cloudflare/next-on-pages/blob/main/internal-packages/next-dev/README.md#recommended-development-workflow))
+## 開発期間
 
-### Bindings
+2024/11〜現在
 
-Cloudflare [Bindings](https://developers.cloudflare.com/pages/functions/bindings/) are what allows you to interact with resources available in the Cloudflare Platform.
+## 使用技術
 
-You can use bindings during development, when previewing locally your application and of course in the deployed application:
+- Next.js(v15)
+- React(v19)
+- Hono
+- D1
+- Drizzle
+- Cloudflare Pages
 
-- To use bindings in dev mode you need to define them in the `next.config.js` file under `setupDevBindings`, this mode uses the `next-dev` `@cloudflare/next-on-pages` submodule. For more details see its [documentation](https://github.com/cloudflare/next-on-pages/blob/05b6256/internal-packages/next-dev/README.md).
+### 参考記事
 
-- To use bindings in the preview mode you need to add them to the `pages:preview` script accordingly to the `wrangler pages dev` command. For more details see its [documentation](https://developers.cloudflare.com/workers/wrangler/commands/#dev-1) or the [Pages Bindings documentation](https://developers.cloudflare.com/pages/functions/bindings/).
+[Cloudflare Pages + Next.js + Hono + D1 + Drizzle で始めるフルスタック構成](https://zenn.dev/da1/articles/cloudflare-nextjs-hono-drizzle)
 
-- To use bindings in the deployed application you will need to configure them in the Cloudflare [dashboard](https://dash.cloudflare.com/). For more details see the  [Pages Bindings documentation](https://developers.cloudflare.com/pages/functions/bindings/).
+## URL
 
-#### KV Example
-
-`c3` has added for you an example showing how you can use a KV binding.
-
-In order to enable the example:
-- Search for javascript/typescript lines containing the following comment:
-  ```ts
-  // KV Example:
-  ```
-  and uncomment the commented lines below it.
-- Do the same in the `wrangler.toml` file, where
-  the comment is:
-  ```
-  # KV Example:
-  ```
-- If you're using TypeScript run the `cf-typegen` script to update the `env.d.ts` file:
-  ```bash
-  npm run cf-typegen
-  # or
-  yarn cf-typegen
-  # or
-  pnpm cf-typegen
-  # or
-  bun cf-typegen
-  ```
-
-After doing this you can run the `dev` or `preview` script and visit the `/api/hello` route to see the example in action.
-
-Finally, if you also want to see the example work in the deployed application make sure to add a `MY_KV_NAMESPACE` binding to your Pages application in its [dashboard kv bindings settings section](https://dash.cloudflare.com/?to=/:account/pages/view/:pages-project/settings/functions#kv_namespace_bindings_section). After having configured it make sure to re-deploy your application.
+[Vimocho](https://vimocho.pages.dev/)


### PR DESCRIPTION
closed #29 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- プロジェクト名が「Next.jsプロジェクト」から「Vimocho」に変更され、特定のアプリケーションに焦点を当てた内容に。
	- 日本語に翻訳されたセクションヘッダーが追加され、「Getting Started」が「概要」に、「Cloudflare integration」が「開発者」に変更。

- **ドキュメンテーション**
	- README.mdが完全に書き直され、アプリケーションの目的が日本語で説明される新しいセクションが追加。
	- 使用技術に関する情報が整理され、具体的な技術スタックが列挙される新しいセクションが追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->