### PR TITLE
それぞれ#とspace keyでも作成できるようにする

### DIFF
--- a/src/app/const/headings.ts
+++ b/src/app/const/headings.ts
@@ -1,0 +1,9 @@
+// libs/constants/headings.ts
+import type { BlockType } from "@/types/type"
+
+export const headingMap: Record<string, BlockType> = {
+  "/h1": "headingOne",
+  "/h2": "headingTwo",
+  "/h3": "headingThree",
+  "/p": "input"
+} as const

--- a/src/components/ui/input/index.tsx
+++ b/src/components/ui/input/index.tsx
@@ -1,4 +1,5 @@
 "use client"
+import { headingMap } from "@/app/const/headings"
 import { BlockElement } from "@/components/ui/input/block"
 import { useBlockElementRef } from "@/lib/hooks/useBlockElementRef"
 import { useBlocks } from "@/lib/hooks/useBlocks"
@@ -7,6 +8,7 @@ import {
   deleteBlock,
   findBlock,
   findIndexBlocks,
+  handleBlockConversion,
   scrollElementIntoView
 } from "@/lib/utils/textBlockUtils"
 import type { ChangeEvent, KeyboardEvent } from "react"
@@ -35,32 +37,27 @@ export const Input: React.FC = () => {
   ) => {
     const block = findBlock(blocks, blockId)
     const input = e.target as HTMLInputElement
-    const validTags = ["/h1", "/h2", "/h3"]
-    if (block?.type === "input" && validTags.includes(input.value)) {
-      e.preventDefault()
-      switch (input.value) {
-        case "/h1":
-          updateBlockType(blockId, "headingOne")
-          break
-        case "/h2":
-          updateBlockType(blockId, "headingTwo")
-          break
-        case "/h3":
-          updateBlockType(blockId, "headingThree")
-          break
-        default:
-          break
-      }
-      updateBlockContent(blockId, "")
-      animateBlockFocus(blockId, focusBlockElement)
+    if (block?.type === "input" && input.value in headingMap) {
+      handleBlockConversion(
+        e,
+        blockId,
+        headingMap[input.value],
+        updateBlockType,
+        updateBlockContent,
+        focusBlockElement
+      )
       return
     }
 
     if (block?.type !== "input" && input.value === "/p") {
-      e.preventDefault()
-      updateBlockType(blockId, "input")
-      updateBlockContent(blockId, "")
-      animateBlockFocus(blockId, focusBlockElement)
+      handleBlockConversion(
+        e,
+        blockId,
+        headingMap[input.value],
+        updateBlockType,
+        updateBlockContent,
+        focusBlockElement
+      )
       return
     }
 

--- a/src/components/ui/input/index.tsx
+++ b/src/components/ui/input/index.tsx
@@ -49,6 +49,21 @@ export const Input: React.FC = () => {
       return
     }
 
+    if (e.code === "Space" && /^#{1,3}$/.test(input.value)) {
+      const level = input.value.length
+      const headingType =
+        `heading${level === 1 ? "One" : level === 2 ? "Two" : "Three"}` as const
+      handleBlockConversion(
+        e,
+        blockId,
+        headingType,
+        updateBlockType,
+        updateBlockContent,
+        focusBlockElement
+      )
+      return
+    }
+
     if (block?.type !== "input" && input.value === "/p") {
       handleBlockConversion(
         e,

--- a/src/lib/utils/textBlockUtils.ts
+++ b/src/lib/utils/textBlockUtils.ts
@@ -1,4 +1,5 @@
 import type { Block, BlockType } from "@/types/type"
+import type { ChangeEvent, KeyboardEvent } from "react"
 
 export const findIndexBlocks = (blocks: Block[], blockId: string): number =>
   blocks.findIndex((block) => block.id === blockId)
@@ -57,4 +58,18 @@ export const getBlockHeight = (type: BlockType): string => {
     return "min-h-[2rem]"
   }
   return "min-h-[1rem]"
+}
+
+export const handleBlockConversion = (
+  e: KeyboardEvent<HTMLInputElement> | ChangeEvent<HTMLInputElement>,
+  blockId: string,
+  blockType: BlockType,
+  updateBlockType: (blockId: string, type: BlockType) => void,
+  updateBlockContent: (blockId: string, content: string) => void,
+  focusBlockElement: (blockId: string) => void
+) => {
+  e.preventDefault()
+  updateBlockType(blockId, blockType)
+  updateBlockContent(blockId, "")
+  animateBlockFocus(blockId, focusBlockElement)
 }


### PR DESCRIPTION
closed #22 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 新しい定数 `headingMap` を追加し、異なる見出しレベルと段落をマッピング。
  - `Input` コンポーネントのキーダウンイベント処理を改善し、見出しの変換を動的に行うロジックを実装。

- **バグ修正**
  - `/p` 入力の処理を改善し、冗長性を削減。

- **ドキュメント**
  - 新しい関数 `handleBlockConversion` を追加し、ブロックタイプとコンテンツの更新を管理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->